### PR TITLE
rename class Object because `object` has become a reserved word which

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ PHP API "КЛАДР в облаке"
 
 
 
-**Kladr\Object**
+**Kladr\ObjectKladr**
 
 Объект КЛАДР
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -97,7 +97,7 @@ class Api
 
         $arObjects = array();
         foreach ($obResult->result as $obObject) {
-            $arObjects[] = new Object($obObject);
+            $arObjects[] = new ObjectKladr($obObject);
         }
 
         return $arObjects;

--- a/src/Object.php
+++ b/src/Object.php
@@ -2,69 +2,14 @@
 
 namespace Kladr;
 
-/**
- * Объект КЛАДР
- * @property-read string          $Id          Идентификатор объекта
- * @property-read string          $Name        Название объекта
- * @property-read string          $Zip         Почтовый индекс объекта
- * @property-read string          $Type        Тип объекта полностью (область, район)
- * @property-read string          $TypeShort   Тип объекта коротко (обл, р-н)
- * @property-read string          $ContentType Тип объекта из перечисления ObjectType
- * @property-read string          $Okato       ОКАТО объекта
- * @property-read \Kladr\Object[] $Parents     Массив родительских объектов
+/*
+ * It has been replaced by [[ObjectKladr]] because `object` has become a reserved word which can not be
+ * used as class name in PHP 7.2.
+ *
+ * @deprecated, the class name `Object` is invalid since PHP 7.2, use [[ObjectKladr]] instead.
+ * @see https://wiki.php.net/rfc/object-typehint
+ * @see ObjectKladr
  */
-class Object
+class Object extends ObjectKladr
 {
-    private $id;
-    private $name;
-    private $zip;
-    private $type;
-    private $typeShort;
-    private $okato;
-    private $contentType;
-    private $arParents;
-
-    /**
-     * @param $obObject
-     */
-    public function __construct($obObject)
-    {
-        $this->id          = $obObject->id;
-        $this->name        = $obObject->name;
-        $this->zip         = $obObject->zip;
-        $this->type        = $obObject->type;
-        $this->typeShort   = $obObject->typeShort;
-        $this->okato       = $obObject->okato;
-        $this->contentType = $obObject->contentType;
-
-        $this->arParents = array();
-
-        if (isset($obObject->parents)) {
-            foreach ($obObject->parents as $obParent) {
-                $this->arParents[] = new Object($obParent);
-            }
-        }
-    }
-
-    public function __get($name)
-    {
-        switch ($name) {
-            case 'Id':
-                return $this->id;
-            case 'Name':
-                return $this->name;
-            case 'Zip':
-                return $this->zip;
-            case 'Type':
-                return $this->type;
-            case 'TypeShort':
-                return $this->typeShort;
-            case 'Okato':
-                return $this->okato;
-            case 'ContentType':
-                return $this->contentType;
-            case 'Parents':
-                return $this->arParents;
-        }
-    }
 }

--- a/src/ObjectKladr.php
+++ b/src/ObjectKladr.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Kladr;
+
+/**
+ * Объект КЛАДР
+ * @property-read string               $Id          Идентификатор объекта
+ * @property-read string               $Name        Название объекта
+ * @property-read string               $Zip         Почтовый индекс объекта
+ * @property-read string               $Type        Тип объекта полностью (область, район)
+ * @property-read string               $TypeShort   Тип объекта коротко (обл, р-н)
+ * @property-read string               $ContentType Тип объекта из перечисления ObjectType
+ * @property-read string               $Okato       ОКАТО объекта
+ * @property-read \Kladr\ObjectKladr[] $Parents     Массив родительских объектов
+ */
+class ObjectKladr
+{
+    private $id;
+    private $name;
+    private $zip;
+    private $type;
+    private $typeShort;
+    private $okato;
+    private $contentType;
+    private $arParents;
+
+    /**
+     * @param $obObject
+     */
+    public function __construct($obObject)
+    {
+        $this->id          = $obObject->id;
+        $this->name        = $obObject->name;
+        $this->zip         = $obObject->zip;
+        $this->type        = $obObject->type;
+        $this->typeShort   = $obObject->typeShort;
+        $this->okato       = $obObject->okato;
+        $this->contentType = $obObject->contentType;
+
+        $this->arParents = array();
+
+        if (isset($obObject->parents)) {
+            foreach ($obObject->parents as $obParent) {
+                $this->arParents[] = new ObjectKladr($obParent);
+            }
+        }
+    }
+
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'Id':
+                return $this->id;
+            case 'Name':
+                return $this->name;
+            case 'Zip':
+                return $this->zip;
+            case 'Type':
+                return $this->type;
+            case 'TypeShort':
+                return $this->typeShort;
+            case 'Okato':
+                return $this->okato;
+            case 'ContentType':
+                return $this->contentType;
+            case 'Parents':
+                return $this->arParents;
+        }
+    }
+}


### PR DESCRIPTION
can not be used as class name in PHP 7.2